### PR TITLE
예외 처리 관련 로직 작성

### DIFF
--- a/src/main/java/goormthonUniv/MJU/server/global/exception/CustomLoginException.java
+++ b/src/main/java/goormthonUniv/MJU/server/global/exception/CustomLoginException.java
@@ -1,0 +1,22 @@
+package goormthonUniv.MJU.server.global.exception;
+
+import lombok.Getter;
+import java.time.Instant;
+
+@Getter
+public class CustomLoginException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+    private final Instant occurredAt;
+
+    public CustomLoginException(ExceptionCode exceptionCode){
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+        this.occurredAt = Instant.now();
+    }
+    public CustomLoginException(ExceptionCode exceptionCode, String message){
+        super(exceptionCode.getMessage() + "| 상세 오류 :" + message);
+        this.exceptionCode = exceptionCode;
+        this.occurredAt = Instant.now();
+    }
+}

--- a/src/main/java/goormthonUniv/MJU/server/global/exception/ErrorResponse.java
+++ b/src/main/java/goormthonUniv/MJU/server/global/exception/ErrorResponse.java
@@ -1,0 +1,34 @@
+package goormthonUniv.MJU.server.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Builder
+@Getter
+public class ErrorResponse {
+
+    private final Integer status;
+    private final String code;
+    private final String message;
+    private final Instant occurredAt;
+
+    // 생성자 (@Builder가 생성해주지만, 직접 생성자 만들 수도 있음)
+    public ErrorResponse(Integer status, String code, String message, Instant occurredAt) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+        this.occurredAt = occurredAt;
+    }
+
+    public static ErrorResponse of(CustomLoginException exception) {
+        ExceptionCode code = exception.getExceptionCode();
+        return ErrorResponse.builder()
+                .status(code.getStatus())
+                .code(code.name())
+                .message(code.getMessage())
+                .occurredAt(exception.getOccurredAt())
+                .build();
+    }
+}

--- a/src/main/java/goormthonUniv/MJU/server/global/exception/ExceptionCode.java
+++ b/src/main/java/goormthonUniv/MJU/server/global/exception/ExceptionCode.java
@@ -1,0 +1,18 @@
+package goormthonUniv.MJU.server.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ExceptionCode {
+
+    UNKNOWN_EXCEPTION_OCCURRED(500, "서버 관련 예외")
+    ;
+
+    private final int status;
+    private final String message;
+
+    ExceptionCode(int code, String message){
+        this.status = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/goormthonUniv/MJU/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/goormthonUniv/MJU/server/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package goormthonUniv.MJU.server.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomLoginException.class)
+    public ResponseEntity<ErrorResponse> handleCustomExceptions(CustomLoginException exception){
+        ErrorResponse response = ErrorResponse.of(exception);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(response.getStatus()));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleUnKnownExceptions(RuntimeException exception){
+
+        ErrorResponse response = ErrorResponse.of(
+                new CustomLoginException(ExceptionCode.UNKNOWN_EXCEPTION_OCCURRED, exception.getMessage())
+        );
+
+        return new ResponseEntity<>(response, HttpStatusCode.valueOf(response.getStatus()));
+    }
+}


### PR DESCRIPTION
- RestControllerAdvice를 통해서 전역으로 예외처리 하는 로직을 추가했습니다.
- 사용법은 new CustomLoginException(ExceptonCode.~~~~); 이런식으로 작성하면 됩니다
- 만약 유저가 게시글을 삭제하는 API를 요청했는데 해당 게시글이 A유저가 작성한 것이 아닐 경우에 예시) PostAccessDenied 라고 하면 되고 ExceptionCode에 PostAccessDeniedException(403, "게시글 접근 권한이 없음") 처럼 작성하시면 됩니다.

이해 안가는 거 있으면 카톡으로 물어봐 주세용